### PR TITLE
Fix typo

### DIFF
--- a/signpad2image/signpad2image.py
+++ b/signpad2image/signpad2image.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # vim: ai ts=4 sts=4 et sw=4
-from PiL import Image, ImageDraw
+from PIL import Image, ImageDraw
 import json, sys, os, exceptions
 
 try:


### PR DESCRIPTION
A recent change misspelled PIL and broke the library.
